### PR TITLE
feat: add plugin repository to ease install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,17 @@
     <artifactId>rre-fosdem-walkthrough</artifactId>
     <version>1.0</version>
     <packaging>pom</packaging>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>archetype</id>
+            <name>Sease repository</name>
+            <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
I was stuck as RRE plugins are not on Maven central.
This PR add the plugin repository described in https://github.com/SeaseLtd/rated-ranking-evaluator/wiki/Maven%20Archetype